### PR TITLE
fixed wrong date_exact_iso format

### DIFF
--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -243,7 +243,10 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
             $deliveryEstimateDateExactISO = $child['delivery_estimate_date_exact_iso'] ?? null;
 
             if ($deliveryEstimateDateExactISO) {
-                $child['delivery_estimate_business_days'] = date('d/m/Y', strtotime($deliveryEstimateDateExactISO));
+                $tz       = new \DateTimeZone('America/Sao_Paulo');
+                $today    = new \DateTimeImmutable('today', $tz);
+                $estimate = new \DateTimeImmutable($deliveryEstimateDateExactISO);
+                $child['delivery_estimate_business_days'] = max(1, (int) $estimate->diff($today)->format('%a'));
                 $method->setDeliveryEstimateDateExactIso($deliveryEstimateDateExactISO);
             }
 


### PR DESCRIPTION
**Title:**
Fixed wrong date_exact_iso format
**Description:**
Correct formatting of the difference between the delivery_estimate_date_exact_iso date and the current date has been applied.
